### PR TITLE
bump msrv to 1.62

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 	"SkywardMC Contributors"
 ]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.62"
 description = "Structured bindings for Modrinth's API"
 readme = "README.md"
 repository = "https://github.com/skywardmc/modrinth-api"


### PR DESCRIPTION
turns out we need a stable `derive_default_enum`, which didn't happen
until 1.62
